### PR TITLE
Implement incremental event loading in timeline viewer

### DIFF
--- a/timeline/viewer/src/components/EnhancedTimelineView.css
+++ b/timeline/viewer/src/components/EnhancedTimelineView.css
@@ -124,6 +124,29 @@
   transition: transform 0.3s ease;
 }
 
+.event-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: rgba(30, 41, 59, 0.85);
+  border-bottom: 1px solid #1e293b;
+  padding: 0.75rem 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 85;
+  backdrop-filter: blur(8px);
+}
+
+.event-progress-main {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.event-progress-hint {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
 /* Year Groups */
 .year-group {
   margin-bottom: 4rem;
@@ -656,6 +679,69 @@
 .keyboard-help span {
   color: #94a3b8;
   font-size: 0.75rem;
+}
+
+.load-more-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem 0;
+}
+
+.load-more-button {
+  background: #1d4ed8;
+  color: #f8fafc;
+  border: none;
+  padding: 0.6rem 1.5rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.load-more-button:hover {
+  background: #2563eb;
+  transform: translateY(-1px);
+}
+
+.load-more-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.load-more-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #cbd5f5;
+  font-size: 0.9rem;
+}
+
+.load-more-status.end {
+  color: #94a3b8;
+}
+
+.load-more-spinner {
+  animation: spin 1s linear infinite;
+}
+
+.load-more-sentinel {
+  width: 100%;
+  height: 1px;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* List View */


### PR DESCRIPTION
## Summary
- add client-side pagination and incremental loading to the timeline viewer
- surface event count progress indicators and load-more controls across timeline, list, and grid layouts
- style the new pagination UI elements to match the existing theme

## Testing
- `npm test -- --watch=false` *(fails: jsdom environment lacks required browser APIs and network access)*

------
https://chatgpt.com/codex/tasks/task_e_69085178675c8325bea35a59f0228e4b